### PR TITLE
Request.cpp parseUri bug fix

### DIFF
--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -107,7 +107,7 @@ std::string Request::parseUri(void) {
 	std::string firstLine = this->rawRequest.substr(0, this->rawRequest.find("\r\n"));
 	std::size_t start = firstLine.find(' ');
 	std::size_t end = firstLine.find_last_of(' ');
-	return (firstLine.substr(start + 1, end));
+	return (firstLine.substr(start + 1, end - start));
 }
 
 /*


### PR DESCRIPTION
- Request가 uri를 제대로 파싱하지 못하는 버그를 수정했습니다. 
close #5 