### PR TITLE
ServerConfig getServers() segfault hotfix

### DIFF
--- a/includes/ServerConfig.hpp
+++ b/includes/ServerConfig.hpp
@@ -28,7 +28,7 @@ class ServerConfig
 		~ServerConfig();
 
 		static ServerConfig*	getInstance();
-		std::vector<Server>		getServers();
+		std::vector<Server>	const	&getServers();
 
 		int		checkLine(std::string line);
 		void	configParse(std::string line);

--- a/srcs/ServerConfig.cpp
+++ b/srcs/ServerConfig.cpp
@@ -35,7 +35,7 @@ ServerConfig* ServerConfig::getInstance()
 /*
 	private 멤버 변수 server 반환 getter
 */
-std::vector<Server> ServerConfig::getServers()
+std::vector<Server> const &ServerConfig::getServers()
 {
 	return server;
 }


### PR DESCRIPTION
- ServerConfig::getServers() 함수가 const 레퍼런스가 아닌 생성자를 호출하여 생기는 문제 수정