### PR TITLE
Request의 uri를 rawUri로 수정, uri에서 directory 파싱

### DIFF
--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -18,7 +18,8 @@ class Request
 
 		//getter
 		std::string getMethod(void) const;
-		std::string getUri(void) const;
+		std::string getRawUri(void) const;
+		std::string getDirectory(void) const;
 		std::string getHttpVersion(void) const;
 		std::string getRawHeader(void) const;
 		std::map<std::string, std::string> getHeader(void) const;
@@ -34,7 +35,9 @@ class Request
 		std::string	rawRequest;
 
 		std::string	method;
-		std::string	uri;
+		std::string rawUri;
+		//uri에서 파싱된 directory, 아니라면 rawUri와 동일
+		std::string directory;
 		std::string	httpVersion;
 
 		std::string rawHeader;
@@ -44,6 +47,7 @@ class Request
 
 		std::string parseMethod(void);
 		std::string parseUri(void);
+		std::string parseDirectory(void);
 		std::string parseHttpVersion(void);
 		std::map<std::string, std::string> parseHeader(std::string);
 };

--- a/includes/Request.hpp
+++ b/includes/Request.hpp
@@ -19,6 +19,7 @@ class Request
 		//getter
 		std::string getMethod(void) const;
 		std::string getRawUri(void) const;
+		std::string getUri(void) const;
 		std::string getDirectory(void) const;
 		std::string getHttpVersion(void) const;
 		std::string getRawHeader(void) const;
@@ -36,7 +37,9 @@ class Request
 
 		std::string	method;
 		std::string rawUri;
-		//uri에서 파싱된 directory, 아니라면 rawUri와 동일
+		//rawUri에서 쿼리스트링/가상경로를 제거한 경로
+		std::string uri;
+		//rawUri에서 파일명/쿼리스트링/가상경로를 제거한 directory 경로, 아니라면 rawUri와 동일
 		std::string directory;
 		std::string	httpVersion;
 
@@ -46,6 +49,7 @@ class Request
 		std::string	rawBody;
 
 		std::string parseMethod(void);
+		std::string parseRawUri(void);
 		std::string parseUri(void);
 		std::string parseDirectory(void);
 		std::string parseHttpVersion(void);

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -170,6 +170,11 @@ std::string Request::getMethod(void) const {	return this->method;	}
 std::string Request::getRawUri(void) const {	return this->rawUri;	}
 
 /*
+* rawUri에서 파싱된 경로값을 취합니다.
+*/
+std::string Request::getDirectory(void) const {	return this->directory;	}
+
+/*
 * http 버전 값을 취합니다.
 */
 std::string Request::getHttpVersion(void) const {	return this->httpVersion;	}

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -77,7 +77,7 @@ void Request::initRequest(void)
 }
 
 /*
-* 가공되지 않은 요청 문자열을 가져와 method, rawUri, httpVersion, header, body를 파싱합니다.
+* 가공되지 않은 HTTP 요청 문자열을 가져와 method, rawUri, httpVersion, header, body를 파싱합니다.
 */
 void Request::parseRequest(void)
 {
@@ -96,14 +96,14 @@ void Request::parseRequest(void)
 }
 
 /*
-* 가공되지 않은 요청 문자열에서 method를 파싱합니다.
+* 가공되지 않은 HTTP 요청 문자열에서 method를 파싱합니다.
 */
 std::string Request::parseMethod(void) {
 	return (this->rawRequest.substr(0, rawRequest.find(' ')));
 }
 
 /*
-* 가공되지 않은 요청 문자열에서 uri를 파싱합니다.
+* 가공되지 않은 HTTP 요청 문자열에서 uri를 파싱합니다.
 */
 std::string Request::parseUri(void) {
 	std::string firstLine = this->rawRequest.substr(0, this->rawRequest.find("\r\n"));
@@ -122,7 +122,7 @@ std::string Request::parseDirectory(void) {
 }
 
 /*
-* 가공되지 않은 요청 문자열에서 HTTP 버전을 파싱합니다.
+* 가공되지 않은 HTTP 요청 문자열에서 HTTP 버전을 파싱합니다.
 */
 std::string Request::parseHttpVersion(void) {
 	std::string firstLine = this->rawRequest.substr(0, this->rawRequest.find("\r\n"));
@@ -130,7 +130,7 @@ std::string Request::parseHttpVersion(void) {
 }
 
 /*
-* 가공되지 않은 요청 문자열에서 헤더를 키와 밸류값으로 나누어 파싱합니다.
+* 가공되지 않은 HTTP 요청 문자열에서 헤더를 키와 밸류값으로 나누어 파싱합니다.
 */
 std::map<std::string, std::string> Request::parseHeader(std::string rawHeader)
 {
@@ -155,7 +155,7 @@ std::map<std::string, std::string> Request::parseHeader(std::string rawHeader)
 }
 
 /*
-* 가공되지 않은 요청 문자열에 인자로 받은 string을 할당합니다.
+* 가공되지 않은 HTTP 요청 문자열에 인자로 받은 string을 할당합니다.
 */
 void Request::setRawRequest(std::string data){	this->rawRequest = data;	}
 

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -20,7 +20,8 @@ Request::Request( const Request & src )
 {
 	setRawRequest(src.rawHeader);
 	this->method = src.getMethod();
-	this->uri = src.getUri();
+	this->rawUri = src.getRawUri();
+	this->directory = src.getDirectory();
 	this->httpVersion = src.getHttpVersion();
 	this->rawHeader = src.getRawHeader();
 	this->header = src.getHeader();
@@ -45,7 +46,8 @@ Request &				Request::operator=( Request const & rhs )
 	{
 		setRawRequest(rhs.rawHeader);
 		this->method = rhs.getMethod();
-		this->uri = rhs.getUri();
+		this->rawUri = rhs.getRawUri();
+		this->directory = rhs.getDirectory();
 		this->httpVersion = rhs.getHttpVersion();
 		this->rawHeader = rhs.getRawHeader();
 		this->header = rhs.getHeader();
@@ -64,7 +66,8 @@ Request &				Request::operator=( Request const & rhs )
 void Request::initRequest(void)
 {
 	this->method.clear();
-	this->uri.clear();
+	this->rawUri.clear();
+	this->directory.clear();
 	this->httpVersion.clear();
 
 	this->rawHeader.clear();
@@ -74,12 +77,13 @@ void Request::initRequest(void)
 }
 
 /*
-* 가공되지 않은 요청 문자열을 가져와 method, uri, httpVersion, header, body를 파싱합니다.
+* 가공되지 않은 요청 문자열을 가져와 method, rawUri, httpVersion, header, body를 파싱합니다.
 */
 void Request::parseRequest(void)
 {
 	this->method = parseMethod();
-	this->uri = parseUri();
+	this->rawUri = parseUri();
+	this->directory = parseDirectory();
 	this->httpVersion = parseHttpVersion();
 
 	std::size_t headerStartPos = this->rawRequest.find("\r\n") + 2;
@@ -106,6 +110,15 @@ std::string Request::parseUri(void) {
 	std::size_t start = firstLine.find(' ');
 	std::size_t end = firstLine.find_last_of(' ');
 	return (firstLine.substr(start + 1, end - start - 1));
+}
+
+/*
+* rawUri에서 directory를 파싱합니다. uri가 directory이거나 /가 존재하지 않을 경우 반환값은 rawUri와 동일합니다.
+*/
+std::string Request::parseDirectory(void) {
+	if (this->rawUri[this->rawUri.size() - 1] == '/' || this->rawUri.find('/') == std::string::npos)
+		return this->rawUri;
+	return (this->rawUri.substr(0, this->rawUri.find_last_of('/') + 1));
 }
 
 /*
@@ -152,9 +165,9 @@ void Request::setRawRequest(std::string data){	this->rawRequest = data;	}
 std::string Request::getMethod(void) const {	return this->method;	}
 
 /*
-* uri 값을 취합니다.
+* rawUri 값을 취합니다.
 */
-std::string Request::getUri(void) const {	return this->uri;	}
+std::string Request::getRawUri(void) const {	return this->rawUri;	}
 
 /*
 * http 버전 값을 취합니다.

--- a/srcs/ResponseHandler.cpp
+++ b/srcs/ResponseHandler.cpp
@@ -148,7 +148,7 @@ Response ResponseHandler::makeResponse()
 		else if (request.getMethod() == "CONNECT")
 			makeConnectResponse();
 
-		this->resourcePath = request.getRawUri(); //나중에 root 들어오면 앞에 붙여주세요
+		this->resourcePath = request.getUri(); //나중에 root 들어오면 앞에 붙여주세요
 		//경로 한번 더 검사-> 존재 안하면
 		if (checkPath(this->resourcePath) == NOT_FOUND && request.getMethod() != "PUT" && request.getMethod() != "POST")
 			throwErrorResponse(NOT_FOUND, request.getHttpVersion());
@@ -370,7 +370,7 @@ std::string ResponseHandler::makeAutoIndexPage(std::string resourcePath)
 	body += "<head>";
 	body += "</head>";
 	body += "<body>";
-	body += "<h1> Index of "+ request.getRawUri() + "</h1>";
+	body += "<h1> Index of "+ request.getUri() + "</h1>";
 
 	DIR *dir = NULL;
 	if ((dir = opendir(resourcePath.c_str())) == NULL)

--- a/srcs/ResponseHandler.cpp
+++ b/srcs/ResponseHandler.cpp
@@ -130,7 +130,7 @@ Response ResponseHandler::makeResponse()
 	*/
 
 	try{
-		location = server->getLocation(request.getUri());
+		location = server->getLocation(request.getDirectory());
 		if (location == NULL)
 			throwErrorResponse(NOT_FOUND, request.getHttpVersion());
 
@@ -148,7 +148,7 @@ Response ResponseHandler::makeResponse()
 		else if (request.getMethod() == "CONNECT")
 			makeConnectResponse();
 
-		this->resourcePath = request.getUri(); //나중에 root 들어오면 앞에 붙여주세요
+		this->resourcePath = request.getRawUri(); //나중에 root 들어오면 앞에 붙여주세요
 		//경로 한번 더 검사-> 존재 안하면
 		if (checkPath(this->resourcePath) == NOT_FOUND && request.getMethod() != "PUT" && request.getMethod() != "POST")
 			throwErrorResponse(NOT_FOUND, request.getHttpVersion());
@@ -370,7 +370,7 @@ std::string ResponseHandler::makeAutoIndexPage(std::string resourcePath)
 	body += "<head>";
 	body += "</head>";
 	body += "<body>";
-	body += "<h1> Index of "+ request.getUri() + "</h1>";
+	body += "<h1> Index of "+ request.getRawUri() + "</h1>";
 
 	DIR *dir = NULL;
 	if ((dir = opendir(resourcePath.c_str())) == NULL)


### PR DESCRIPTION
- uri 변수를 rawUri로 수정
- rawUri를 /기준으로 파싱해 directory 변수에 저장하는 parseDirectory 함수 추가
- location 검색을 rawUri가 아닌 directory에서 진행
#19 